### PR TITLE
ESP32-CAM 실시간 영상 스트리밍 API 구현

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,11 +6,15 @@ from sqlalchemy.orm import Session
 from database import SessionLocal, engine
 from models import user as models
 from schemas import user as schemas
+from routers.websocket_handler import router as websocket_router
 
 # 앱 실행 시 테이블 자동 생성
 models.Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+#WebSocket 핸들러(router)를 FastAPI 애플리케이션에 등록
+app.include_router(websocket_router)    #/ws/video_feed (ESP32용) 및 /ws/video (브라우저용) 경로에서 웹소켓 통신 처리
 
 # DB 세션 의존성 함수 (요청마다 DB 세션 생성 -> 자동 닫힘)
 def get_db():

--- a/routers/websocket_handler.py
+++ b/routers/websocket_handler.py
@@ -1,0 +1,48 @@
+"""
+esp32 cam 실시간 스트리밍 라우터
+"""
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+# FastAPI용 라우터 객체 생성
+router = APIRouter()
+
+# 실시간 스트리밍을 받을 웹소켓 클라이언트 목록 (웹 브라우저 사용자)
+clients_list = []
+
+#ESP32-CAM으로부터 실시간 영상 데이터를 수신하는 WebSocket 엔드포인트
+@router.websocket("/ws/video_feed")
+async def video_feed(websocket: WebSocket):
+    await websocket.accept()
+    print("📡 ESP32 Connected")
+    try:
+        while True:
+            # ESP32로부터 바이트 형태의 영상 프레임 수신
+            data = await websocket.receive_bytes()
+
+            # 수신한 데이터를 모든 클라이언트(웹 브라우저)에 브로드캐스트
+            for client in clients_list:
+                try:
+                    await client.send_bytes(data)
+                except Exception:
+                    # 전송 중 오류 발생 시 무시하고 다음 클라이언트로
+                    pass
+    except WebSocketDisconnect:
+        print("❌ ESP32 Disconnected")
+
+#웹 브라우저 사용자(뷰어)와 연결되는 WebSocket 엔드포인트
+@router.websocket("/ws/video")
+async def video_viewer(websocket: WebSocket):
+    # 연결 수락
+    await websocket.accept()
+    print("👀 Viewer Connected")
+
+    # 현재 클라이언트를 클라이언트 목록에 추가
+    clients_list.append(websocket)
+    try:
+        while True:
+            # ping 유지용 메시지 수신 (실제 데이터 없음)
+            await websocket.receive_text()  # ping 유지용
+    except WebSocketDisconnect:
+        print("👋 Viewer Disconnected")
+        # 연결이 끊긴 클라이언트를 목록에서 제거
+        clients_list.remove(websocket)


### PR DESCRIPTION
[#5] 📡 WebSocket 라우터 main.py에 등록

## ✅ 주요 구현 내용

- WebSocket 핸들러(router)를 FastAPI 애플리케이션에 등록
- /ws/video_feed : ESP32로부터 실시간 영상 프레임 수신
- /ws/video : 브라우저 클라이언트에 영상 프레임 브로드캐스트
- 라우터 등록 시 이해를 돕기 위한 한글 주석 추가

## 🔌 라우터 통합 방식

- websocket/handler.py에서 APIRouter로 정의된 router를 main.py에서 include_router로 통합
- 앱 실행 시 웹소켓 경로 자동 활성화

## 📂 관련 파일

- main.py: FastAPI 진입점, 라우터 등록
- websocket/handler.py: WebSocket 핸들러 정의
- websocket/__init__.py: 패키지 인식용 빈 모듈

## 💡 추가 설명

- 웹소켓 서버는 ESP32-CAM → 서버 → 브라우저 방향의 영상 중계 구조
- 클라이언트 목록 관리 및 연결 로그 출력 기능 포함

## 🔧 이후 작업 계획

- 바코드 데이터 디코딩 로직 추가 예정 (pyzbar 등 활용)
- QR/ISBN → DB 연동으로 도서 자동 조회 및 등록 기능 개발 예정