### PR TITLE
CORS preflight(OPTIONS) 요청 허용 설정

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 FastAPI 엔드포인트 정의
 """
 from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from database import SessionLocal, engine
 from models import user as models
@@ -12,6 +13,17 @@ from routers.websocket_handler import router as websocket_router
 models.Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+# 허용할 origin 리스트
+origins = ["*"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 #WebSocket 핸들러(router)를 FastAPI 애플리케이션에 등록
 app.include_router(websocket_router)    #/ws/video_feed (ESP32용) 및 /ws/video (브라우저용) 경로에서 웹소켓 통신 처리


### PR DESCRIPTION
##✅ 주요 구현 내용

 - FastAPI 애플리케이션에 CORSMiddleware 적용
 - 프론트엔드 개발 편의를 위해 allow_origins=["*"]로 모든 출처(origin) 허용
 - allow_methods, allow_headers, allow_credentials 옵션을 모두 개방하여 사전 요청(OPTIONS) 포함한 모든 요청 허용

## 🔐 CORS 정책 적용 방식

 - FastAPI 미들웨어로 등록하여 요청 시 자동 적용
 - 클라이언트에서 fetch 또는 axios 요청 시 발생하는 preflight(OPTIONS) 요청을 정상 처리

##📂 관련 파일

 - main.py: FastAPI 진입점, CORS 미들웨어 설정 추가

##💡 추가 설명

 - CORS의 origin은 프로토콜 + 도메인(IP) + 포트 조합으로 판단되므로, 포트 단위 구분이 필요
 - 현재는 전체 허용(*) 상태로 설정되어 있으며, 이후 운영 환경에서는 특정 origin(예: http://210.107.70.233:5173)으로 제한할 예정

## 🔧 이후 작업 계획

 - 운영 배포 시점에 origin 리스트를 명확하게 지정하여 보안 강화
 - .env 또는 설정 파일을 통해 환경별 origin 관리 자동화 검토