### PR TITLE
로그인 & 로그아웃 API 기본 인증 흐름 구현 (JWT 제외)

### DIFF
--- a/database.py
+++ b/database.py
@@ -28,3 +28,11 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 # Base 클래스 (모든 모델 클래스가 이걸 상속)
 Base = declarative_base()
+
+# DB 세션 의존성 함수 (요청마다 DB 세션 생성 -> 자동 닫힘)
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/main.py
+++ b/main.py
@@ -4,10 +4,11 @@ FastAPI 엔드포인트 정의
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
-from database import SessionLocal, engine
+from database import SessionLocal, engine, get_db
 from models import user as models
 from schemas import user as schemas
 from routers.websocket_handler import router as websocket_router
+from routers.auth import router as auth_router
 
 # 앱 실행 시 테이블 자동 생성
 models.Base.metadata.create_all(bind=engine)
@@ -28,13 +29,7 @@ app.add_middleware(
 #WebSocket 핸들러(router)를 FastAPI 애플리케이션에 등록
 app.include_router(websocket_router)    #/ws/video_feed (ESP32용) 및 /ws/video (브라우저용) 경로에서 웹소켓 통신 처리
 
-# DB 세션 의존성 함수 (요청마다 DB 세션 생성 -> 자동 닫힘)
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+app.include_router(auth_router)
 
 # 학번을 통해 사용자 정보를 조회하는 API
 @app.post("/user/by-student-id", response_model=schemas.UserResponse)

--- a/main.py
+++ b/main.py
@@ -29,12 +29,5 @@ app.add_middleware(
 #WebSocket 핸들러(router)를 FastAPI 애플리케이션에 등록
 app.include_router(websocket_router)    #/ws/video_feed (ESP32용) 및 /ws/video (브라우저용) 경로에서 웹소켓 통신 처리
 
+# 인증 라우터를 FastAPI 애플리케이션에 등록
 app.include_router(auth_router)
-
-# 학번을 통해 사용자 정보를 조회하는 API
-@app.post("/user/by-student-id", response_model=schemas.UserResponse)
-def get_user_by_schoolnumber(request: schemas.SchoolNumberRequest, db: Session = Depends(get_db)):
-    user = db.query(models.User).filter(models.User.student_id == request.student_id).first()    # DB에서 학번 기준으로 사용자 조회
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")    # 사용자 없을 경우 404 에러 반환
-    return user    # 조회된 사용자 정보 반환

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,73 @@
+"""
+로그인 및 로그아웃 관련 엔드포인트 정의
+"""
+from fastapi import APIRouter, HTTPException, Depends, status
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+from database import get_db
+from models.user import User
+import httpx
+
+router = APIRouter()
+
+
+# 로그인 요청 스키마
+class LoginRequest(BaseModel):
+    student_id: int
+    password: str
+
+
+# 로그인 응답 스키마
+class LoginResponse(BaseModel):
+    success: bool
+    code: int
+    name: str = None
+    school_id: int = None
+    token: str = None
+
+
+# saint 실서비스 인증 (httpx 비동기 호출)
+async def saint_auth(student_id: int, password: str) -> bool:
+    url = "https://smartid.ssu.ac.kr/smln_pcs.asp"
+    headers = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,/;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "Referer": "https://smartid.ssu.ac.kr/Symtra_sso/smln.asp?apiReturnUrl=https%3A%2F%2Fsaint.ssu.ac.kr%2FwebSSO%2Fsso.jsp",
+    "Origin": "https://smartid.ssu.ac.kr/",
+    }
+    data = {
+        "in_tp_bit": "0",
+        "rqst_caus_cd": "03",
+        "userId": str(student_id),
+        "pwd": password,
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(url, data=data, headers=headers)
+        return "parent.location.href" in response.text
+
+
+# 로그인 엔드포인트
+@router.post("/login", response_model=LoginResponse)
+async def login(data: LoginRequest, db: Session = Depends(get_db)):
+    if not await saint_auth(data.student_id, data.password):
+        raise HTTPException(status_code=400, detail="saint 로그인 실패")
+
+    user = db.query(User).filter(User.student_id == data.student_id).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="사용자 미등록")
+
+    return LoginResponse(
+        success=True,
+        code=200,
+        name=user.name,
+        school_id=user.student_id,
+        token="jwt-token-placeholder",  # JWT 연동 전까지는 placeholder
+    )
+
+
+# 로그아웃 엔드포인트
+@router.post("/logout")
+def logout():
+    return {"success": True, "message": "로그아웃 완료"}


### PR DESCRIPTION
## ✅ 주요 구현 내용

- FastAPI 라우터 기반 `/login`, `/logout` 인증 기능 구현
- saint 시스템 mock 인증을 통한 학번/비밀번호 로그인 처리
- 로그인 성공 시 사용자 정보 및 JWT 토큰 placeholder 반환
- 로그인 실패 시 상황별 코드 분기 응답 처리 (400, 401)
- 로그아웃은 단순 성공 응답 반환

---

## 🔐 로그인 인증 흐름

1. 클라이언트에서 `/login`으로 학번, 비밀번호 POST 요청
2. `saint_auth()` 함수로 saint 시스템 인증 시도 (sToken or HTML 응답 체크)
3. 인증 성공 시 DB에서 사용자 정보 조회
4. 사용자 존재:
    - ✅ 로그인 성공 → 사용자 정보 + 토큰 포함 응답 (`200`)
5. 사용자 없음:
    - ❌ DB 미등록 사용자 → `401 Unauthorized`
6. saint 인증 실패:
    - ❌ 잘못된 비밀번호 등 → `400 Bad Request`

---

## 📂 관련 파일

- `routers/auth.py`  
  로그인 및 로그아웃 관련 라우터 구현

- `main.py`  
  FastAPI 앱에 `auth_router` 등록

---

## 💡 추가 설명

- saint mock 인증은 응답의 `sToken` 존재 여부 또는 `"parent.location.href"` 포함 여부로 판단
- 응답은 API 명세에 맞춰 다음 필드로 구성됨:

```json
{
  "success": true,
  "code": 200,
  "token": "jwt-token-placeholder",
  "name": "홍길동",
  "student_id": 20231234
}
```

- 실패 응답도 일관된 구조 유지:

```json
{
  "success": false,
  "code": 400,
  "data": null
}
```

---

## 🧪 테스트 케이스 대응

시나리오 | 응답 코드 | 설명
-- | -- | --
잘못된 비밀번호 | 400 | saint 인증 실패
미등록 학번 | 401 | DB에 사용자 없음
정상 로그인 | 200 | 사용자 정보 + 토큰 포함

---

## 🔧 이후 작업 계획

- JWT 토큰 발급 로직 구현 및 미들웨어 인증 연동
- /login/result 같은 명확한 redirect 또는 응답 처리 설계
- 로그아웃 시 JWT 무효화 처리 포함한 보안 강화 예정


