### PR TITLE
수동 ISBN 입력 API 구현

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from models import user as models
 from schemas import user as schemas
 from routers.websocket_handler import router as websocket_router
 from routers.auth import router as auth_router
+from routers.manual_input import router as manul_input_router
 
 # 앱 실행 시 테이블 자동 생성
 models.Base.metadata.create_all(bind=engine)
@@ -31,3 +32,5 @@ app.include_router(websocket_router)    #/ws/video_feed (ESP32용) 및 /ws/video
 
 # 인증 라우터를 FastAPI 애플리케이션에 등록
 app.include_router(auth_router)
+
+app.include_router(manul_input_router)

--- a/main.py
+++ b/main.py
@@ -29,12 +29,5 @@ app.add_middleware(
 #WebSocket 핸들러(router)를 FastAPI 애플리케이션에 등록
 app.include_router(websocket_router)    #/ws/video_feed (ESP32용) 및 /ws/video (브라우저용) 경로에서 웹소켓 통신 처리
 
+# 인증 라우터를 FastAPI 애플리케이션에 등록
 app.include_router(auth_router)
-
-# 학번을 통해 사용자 정보를 조회하는 API
-@app.post("/user/by-student-id", response_model=schemas.UserResponse)
-def get_user_by_schoolnumber(request: schemas.SchoolNumberRequest, db: Session = Depends(get_db)):
-    user = db.query(models.User).filter(models.User.student_id == request.student_id).first()    # DB에서 학번 기준으로 사용자 조회
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")    # 사용자 없을 경우 404 에러 반환
-    return user    # 조회된 사용자 정보 반환

--- a/models/items.py
+++ b/models/items.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, String, Integer, Enum
+from database import Base
+import enum
+
+class ItemType(str, enum.Enum):
+    book = "book"
+    daily_item = "daily_item"
+
+class ItemAvailability(str, enum.Enum):
+    available = "available"
+    rented = "rented"
+    not_for_rent = "not_for_rent"
+    lost = "lost"
+    under_repair = "under_repair"
+
+class Item(Base):
+    __tablename__ = "items"
+
+    id = Column(Integer, primary_key=True, index=True, comment="SSCC 물품 고유 넘버")
+    item_type = Column(Enum(ItemType), nullable=False, comment="물품 종류")
+    name = Column(String(255),nullable=False, comment="물품 이름")
+    isbn = Column(String(20), nullable=True, comment="책일 경우 ISBN")
+    is_available = Column(Enum(ItemAvailability), nullable=False, comment="물품 상태")
+    hashtag = Column(String(255), nullable=True, comment="물품 해시태그")

--- a/models/items.py
+++ b/models/items.py
@@ -22,3 +22,4 @@ class Item(Base):
     isbn = Column(String(20), nullable=True, comment="책일 경우 ISBN")
     is_available = Column(Enum(ItemAvailability), nullable=False, comment="물품 상태")
     hashtag = Column(String(255), nullable=True, comment="물품 해시태그")
+    img = Column(String(512), nullable=True, comment="물품 이미지 URL")

--- a/routers/manual_input.py
+++ b/routers/manual_input.py
@@ -15,7 +15,6 @@ def manual_input(request: ManualInputRequest, db: Session = Depends(get_db)):
             success=False,
             code=404
         )
-        #raise HTTPException(status_code=404, detail="Item not found")
 
     return ItemResponse(
         success=True,
@@ -23,5 +22,5 @@ def manual_input(request: ManualInputRequest, db: Session = Depends(get_db)):
         item_id=db_item.id,
         title=db_item.name,
         status=db_item.is_available,
-        img="https://image.yes24.com/goods/118982111/XL"
+        img=db_item.img
     )

--- a/routers/manual_input.py
+++ b/routers/manual_input.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+from database import get_db
+from models.items import Item
+from schemas.item import ManualInputRequest, ItemResponse
+
+router = APIRouter()
+
+@router.post("/api/v0/manual/input", response_model=ItemResponse)
+def manual_input(request: ManualInputRequest, db: Session = Depends(get_db)):
+    db_item = db.query(Item).filter(Item.isbn == request.isbn).first()
+
+    if not db_item:
+        return ItemResponse(
+            success=False,
+            code=404
+        )
+        #raise HTTPException(status_code=404, detail="Item not found")
+
+    return ItemResponse(
+        success=True,
+        code=200,
+        item_id=db_item.id,
+        title=db_item.name,
+        status=db_item.is_available,
+        img="https://image.yes24.com/goods/118982111/XL"
+    )

--- a/schemas/item.py
+++ b/schemas/item.py
@@ -1,0 +1,20 @@
+from enum import Enum
+from pydantic import BaseModel
+
+class ItemAvailability(str, Enum):
+    available = "available"
+    rented = "rented"
+    not_for_rent = "not_for_rent"
+    lost = "lost"
+    under_repair = "under_repair"
+
+class ManualInputRequest(BaseModel):
+    isbn: str
+
+class ItemResponse(BaseModel):
+    success: bool
+    code: int
+    item_id: str = None
+    title: str = None
+    status: ItemAvailability = None
+    img: str = None


### PR DESCRIPTION
## ✅ 주요 구현 내용

- 바코드 인식 실패 시 사용자가 직접 입력한 ISBN을 기반으로 도서 정보 조회 기능 구현
- `/manual/input` POST 엔드포인트 개발 및 FastAPI 라우터 등록
- DB `items` 테이블에서 `item_id`를 기준으로 도서 정보 검색 후 반환
- 조회 성공 및 실패에 따라 일관된 JSON 응답 포맷 유지

---

## 📦 수동 입력 조회 흐름

1. 클라이언트에서 `/manual/input`으로 item_id를 포함해 POST 요청
2. 서버에서 요청 바디에서 item_id 추출
3. DB(`items` 테이블)에서 item_id 기반 조회
4. 결과에 따라
    - ✅ 조회 성공 시: 도서 정보(title, status, img) 포함 응답 (`success: true`)
    - ❌ 조회 실패 시: `404` 코드와 함께 실패 응답 (`success: false`)

---

## 📂 관련 파일

- `routers/manual_input.py`  
  - 수동 입력 API 엔드포인트 구현
- `schemas/item.py`  
  - ManualInputRequest / ItemResponse Pydantic 스키마 정의
- `models/items.py`  
  - `items` 테이블 ORM 모델 작성 (ENUM 타입 적용)
- `main.py`  
  - `manual_input_router` 등록

---

## 💡 추가 설명

- 입력 데이터 검증 및 예외 처리 기본 적용
- `item_id` 기준 조회 실패 시 HTTPException 대신 `{success: false, code: 404}` 형식으로 응답
- 응답 데이터 포맷은 바코드 인식 결과 포맷과 동일하게 맞춤
- 향후 FE와 통합 테스트 예정 (입력 → 조회 → 응답 포맷 확인)

---

## 🔧 이후 작업 계획

- `/rental` (대여 요청) 기능 추가 및 대여 시 상태(is_available) 업데이트 처리
- `/return` (반납 처리) 기능 추가 및 반납 시 상태 복구 처리 예정
- 수동 입력 → 대여 → 반납 전체 플로우 통합 테스트 예정
