### PR TITLE
/rental 대여 요청 API 구현

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,8 @@ from models import user as models
 from schemas import user as schemas
 from routers.websocket_handler import router as websocket_router
 from routers.auth import router as auth_router
-from routers.manual_input import router as manul_input_router
+from routers.manual_input import router as manual_input_router
+from routers.rental import router as rental_router
 
 # 앱 실행 시 테이블 자동 생성
 models.Base.metadata.create_all(bind=engine)
@@ -27,10 +28,14 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-#WebSocket 핸들러(router)를 FastAPI 애플리케이션에 등록
-app.include_router(websocket_router)    #/ws/video_feed (ESP32용) 및 /ws/video (브라우저용) 경로에서 웹소켓 통신 처리
+# WebSocket 핸들러 등록 (/ws/video_feed, /ws/video)
+app.include_router(websocket_router)
 
-# 인증 라우터를 FastAPI 애플리케이션에 등록
+# 인증 라우터 등록
 app.include_router(auth_router)
 
-app.include_router(manul_input_router)
+# 수동 입력(manual input) 라우터 등록
+app.include_router(manual_input_router)
+
+# 대여 요청(rental) 라우터 등록
+app.include_router(rental_router)

--- a/models/rentals.py
+++ b/models/rentals.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, DateTime, Date, Boolean, ForeignKey
+from database import Base
+
+class Rental(Base):
+    __tablename__ = "rentals"
+
+    id = Column(Integer, primary_key=True, index=True, comment="대여 고유 관리 번호")
+    student_id = Column(Integer, nullable=False, comment="대여자 학번")
+    item_id = Column(Integer, ForeignKey("items.id"), nullable=False, comment="아이템 고유번호")
+    rental_date = Column(DateTime, nullable=False, comment="대여일")
+    expectation_return_date = Column(Date, nullable=False, comment="반납 예정일")
+    return_date = Column(DateTime, nullable=True, comment="반납일")
+    overdue = Column(Integer, default=0, comment="연체 여부 및 연체일 수")
+    returned = Column(Boolean, default=False, nullable=False, comment="반납 여부")
+    wish_student_id = Column(Integer, ForeignKey("users.student_id"), nullable=True, comment="희망 인원 학번")

--- a/routers/rental.py
+++ b/routers/rental.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from database import get_db
+from schemas.rental import RentalRequest, RentalResponse
+from models.rentals import Rental
+from models.items import Item
+
+router = APIRouter()
+
+@router.post("/api/v0/rental", response_model=RentalResponse)
+def rental_item(request: RentalRequest, db: Session = Depends(get_db)):
+    rental = Rental(
+        student_id=request.student_id,
+        item_id=request.item_id,
+        rental_date=request.rental_date,
+        expectation_return_date=request.expectation_return_date,
+        returned=False,
+        overdue=0
+    )
+    db.add(rental)
+    
+    item = db.query(Item).filter(Item.id == request.item_id).first()
+
+    if not item:
+        return RentalResponse(
+            success=False,
+            code=404
+        )
+    
+    item.is_available = "rented"
+
+    db.commit()
+
+    return RentalResponse(
+        success=True,
+        code=200
+    )

--- a/schemas/rental.py
+++ b/schemas/rental.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from datetime import datetime, date
+
+class RentalRequest(BaseModel):
+    student_id: int
+    item_id: int
+    rental_date: datetime
+    expectation_return_date: date
+
+class RentalResponse(BaseModel):
+    success: bool
+    code: int


### PR DESCRIPTION
## ✅ 주요 구현 내용

- FastAPI 라우터 기반 `/rental` 대여 요청 기능 구현
- 사용자가 물품(item_id)을 선택하여 대여 요청 처리
- rentals 테이블에 대여 기록 생성 및 관리
- 대여 성공 시 items 테이블 상태(status)를 "rented"로 변경
- 대여 실패(물품 미존재) 시 일관된 실패 응답 반환

---

## 🔐 대여 요청 흐름

1. 클라이언트에서 `/rental`로 student_id, item_id, rental_date, expectation_return_date를 포함해 POST 요청
2. rentals 테이블에 대여 기록 삽입
3. items 테이블에서 item_id에 해당하는 물품 조회
4. 물품 존재 여부에 따라
    - ✅ 물품 존재 시 → 상태(status)를 "rented"로 업데이트 후 success 응답 (`200`)
    - ❌ 물품 미존재 시 → 실패 응답 (`404`)

---

## 📂 관련 파일

- `routers/rental.py`  
  대여 요청 라우터 구현

- `schemas/rental.py`  
  RentalRequest, RentalResponse 스키마 정의

- `models/rentals.py`  
  rentals 테이블 ORM 모델 정의

- `main.py`  
  rental_router 등록

---

## 💡 추가 설명

- 대여 성공/실패에 관계없이 RentalResponse 스키마로 일관된 응답 포맷 유지
- rentals 테이블과 items 테이블 업데이트는 같은 트랜잭션 내 처리
- 응답은 API 명세에 맞춰 다음 필드로 구성됨:

```json
성공 시:
{
  "success": true,
  "code": 200
}

실패 시 (물품 미존재):
{
  "success": false,
  "code": 404
}
```

---

## 🧪 테스트 케이스 대응

| 시나리오 | 응답 코드 | 설명 |
|:---|:---|:---|
| 물품 존재하지 않음 | 404 | item_id 조회 실패 |
| 물품 정상 대여 | 200 | 대여 기록 추가 및 상태 업데이트 성공 |

---

## 🔧 이후 작업 계획

- 반납 처리(`/return`) 기능 추가
- 대여 시 연체 여부(overdue) 및 반납일(return_date) 자동 관리 기능 확장
- 희망 인원(wish_student_id) 등록 기능 추가 예정



